### PR TITLE
remove osgi direct dependencies from pom.xml, just use dep-management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -694,24 +694,6 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.annotation.bundle</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.framework</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.component.annotations</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.osgi</groupId>
-          <artifactId>org.osgi.util.function</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>


### PR DESCRIPTION
- Removed org.osgi.annotation.bundle dependency
- Removed org.osgi.framework dependency
- Removed org.osgi.service.component.annotations dependency
- Removed exclusion for org.osgi.util.function
- Kept junit-jupiter-api dependency
- Cleaned up unnecessary dependencies