### PR TITLE
Remove dep. with transitiv OSGi dependencies from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -718,45 +718,8 @@
       <artifactId>awaitility</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.test.common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.test.assertj.framework</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.test.assertj.log</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.test.assertj.promise</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.test.junit5</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.test.junit5.cm</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jacoco</groupId>
-      <artifactId>org.jacoco.agent</artifactId>
-      <classifier>runtime</classifier>
-      <scope>test</scope>
-    </dependency>
-    <!-- @ServiceProvider for test-jar:
-        better `-resolve.effective: active`-->
-    <dependency>
-      <groupId>biz.aQute.bnd</groupId>
-      <artifactId>biz.aQute.bndlib</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
- Removed org.osgi.test.common dependency
- Removed org.osgi.test.assertj.framework dependency
- Removed org.osgi.test.assertj.log dependency
- Removed org.osgi.test.assertj.promise dependency
- Removed org.osgi.test.junit5 and junit5.cm dependencies
- Removed org.jacoco.agent dependency