### PR TITLE
Update Maven configuration for snapshot repository and plugin changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
     <url>https://github.com/eclipse-osgi-technology/maven-pom/issues</url>
   </issueManagement>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <repositories>
     <repository>
@@ -814,12 +820,6 @@
     </profile>
     <profile>
       <id>deploy</id>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
       <build>
         <plugins>
           <plugin>
@@ -835,15 +835,8 @@
             <artifactId>maven-gpg-plugin</artifactId>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.7.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
- Added `distributionManagement` for snapshot repository
- Replaced `ossrh` with `central` in snapshot repository configuration
- Removed `nexus-staging-maven-plugin` from deploy profile
- Added `central-publishing-maven-plugin` to deploy profile
- Updated URLs to use Sonatype Central repository